### PR TITLE
RAGtruth integration (#25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx>=0.28.1",
     "hydra-core>=1.3.2",
     "lettucedetect>=0.1.8",
-    "nltk>=3.9.1",
+    "nltk>=3.9.4",
     "protobuf>=6.32.1",
     "python-dotenv>=1.0.1",
     "openai>=1.4.0",
@@ -111,6 +111,15 @@ ignore = [
     "E501",
 ]
 "src/scripts/ground_truth/generate_hallucination_dataset.py" = [
+    "E501",
+]
+"src/scripts/train_hallucination_detector.py" = [
+    "E501",
+]
+"src/scripts/translate.py" = [
+    "E501",
+]
+"src/scripts/generate_hallucination_dataset.py" = [
     "E501",
 ]
 "src/scripts/train_hallucination_detector.py" = [

--- a/src/scripts/evaluate_ground_truth.py
+++ b/src/scripts/evaluate_ground_truth.py
@@ -1,0 +1,123 @@
+"""Validate the trained hallucination detector against token-level labels.
+
+This script loads the synthetic-hallucinations dataset from the HuggingFace Hub
+(it is not regenerated), uses its ``hallucinated_labels`` column as ground truth,
+and computes token-level metrics via ``lettucedetect``'s ``evaluate_model``. Its
+purpose is to check whether the trained detection method can identify
+hallucinated tokens.
+
+Usage:
+    uv run src/scripts/evaluate_ground_truth.py <config_key>=<config_value> ...
+"""
+
+import logging
+import os
+
+import hydra
+import torch
+from datasets import load_dataset
+from dotenv import load_dotenv
+from lettucedetect import HallucinationDataset
+from lettucedetect.models.evaluator import evaluate_model, print_metrics
+from omegaconf import DictConfig
+from torch.utils.data import DataLoader
+from transformers import (
+    AutoModelForTokenClassification,
+    AutoTokenizer,
+    DataCollatorForTokenClassification,
+)
+
+from factuality_eval.dataset_generation import (
+    generate_lettucedetect_hallucination_samples,
+)
+from factuality_eval.train import format_dataset_to_ragtruth
+
+load_dotenv()
+
+logger = logging.getLogger("evaluate_ground_truth")
+
+
+def _training_sources_suffix(config: DictConfig) -> str:
+    """Return the model-name suffix used by the training script."""
+    sources = []
+    if config.multiwikiqa.enable:
+        sources.append("mwqa")
+    if config.ragtruth.enable:
+        sources.append("ragtruth")
+    return f"-{'+'.join(sources)}" if sources else ""
+
+
+def _resolve_model_path(config: DictConfig, target_dataset_name: str) -> str:
+    """Return the local model directory if it exists, else the Hub repo id."""
+    suffix = _training_sources_suffix(config)
+    local_path = (
+        f"{config.training.output_dir}/"
+        f"{config.models.hallu_detect_model}-{target_dataset_name}-"
+        f"{config.language}{suffix}"
+    )
+    if os.path.isdir(local_path):
+        logger.info(f"Using local model checkpoint at {local_path}")
+        return local_path
+
+    hub_path = (
+        f"{config.hub_organisation}/"
+        f"{config.models.hallu_detect_model}-{target_dataset_name}-"
+        f"{config.language}{suffix}"
+    )
+    logger.info(f"Local checkpoint not found; using Hub model {hub_path}")
+    return hub_path
+
+
+@hydra.main(
+    config_path="../../config", config_name="hallucination_detection", version_base=None
+)
+def main(config: DictConfig) -> None:
+    """Run token-level validation for the trained hallucination detector."""
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    target_dataset_name = f"{config.base_dataset.id}-synthetic-hallucinations"
+    model_path = _resolve_model_path(config, target_dataset_name)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    logger.info("Running token-level ground-truth evaluation")
+
+    dataset = load_dataset(
+        f"{config.hub_organisation}/{target_dataset_name}", name=config.language
+    )
+    test_split = dataset["train"].train_test_split(
+        test_size=0.2, seed=42, shuffle=False
+    )["test"]
+
+    test_ragtruth = format_dataset_to_ragtruth(
+        test_split, language=config.language, split="test"
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.models.pretrained_model, trust_remote_code=True
+    )
+    data_collator = DataCollatorForTokenClassification(
+        tokenizer=tokenizer, label_pad_token_id=-100
+    )
+    test_hallu_dataset = HallucinationDataset(
+        generate_lettucedetect_hallucination_samples(test_ragtruth),
+        tokenizer,
+        max_length=config.training.max_length,
+    )
+    test_loader = DataLoader(
+        test_hallu_dataset,
+        batch_size=config.training.batch_size,
+        shuffle=False,
+        collate_fn=data_collator,
+    )
+
+    model = AutoModelForTokenClassification.from_pretrained(
+        model_path, trust_remote_code=True
+    )
+    model.to(device)
+
+    metrics = evaluate_model(model, test_loader, device)
+    print_metrics(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/generate_hallucination_dataset.py
+++ b/src/scripts/generate_hallucination_dataset.py
@@ -1,0 +1,175 @@
+"""Generate hallucination-annotated dataset.
+
+Usage:
+    uv run src/scripts/generate_hallucination_dataset.py <config_key>=<config_value> ...
+
+The script generates answers with the eval model and then tags hallucinated
+segments using the hallucination classifier. The output JSONL contains per-row
+question, context, answer, and hallucinated tokens with their character spans
+(relative to the answer string).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import hydra
+from datasets import Dataset
+from dotenv import load_dotenv
+from lettucedetect.models.inference import HallucinationDetector
+from omegaconf import DictConfig
+
+from factuality_eval.dataset_generation import load_qa_data
+from factuality_eval.model_generation import generate_answers_from_qa_data
+from factuality_eval.prompt_utils import Lang, PromptUtils
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def _build_detector_model_path(config: DictConfig) -> str:
+    target_dataset_name = f"{config.base_dataset.id}-synthetic-hallucinations"
+    return (
+        f"{config.hub_organisation}/"
+        f"{config.models.hallu_detect_model}-{target_dataset_name}-{config.language}"
+    )
+
+
+def _format_context(context: list | tuple | str) -> list[str]:
+    """Normalize an arbitrary context value to a list of strings."""
+    if isinstance(context, (list, tuple)):
+        return [str(c) for c in context]
+    return [str(context)]
+
+
+def _extract_hallucinated_tokens(
+    detector: HallucinationDetector,
+    context: list[str],
+    question: str,
+    answer: str,
+    lang: Lang,
+) -> list[dict[str, Any]]:
+    prompt = PromptUtils.format_context(context, question, lang)
+
+    # Use detector's span output to avoid offset drift between our formatter and the model tokenizer.
+    spans = detector.predict_prompt(prompt=prompt, answer=answer, output_format="spans")
+
+    # Normalize span schema without confidence/probability.
+    normalized: list[dict[str, Any]] = []
+    for span in spans:
+        normalized.append(
+            {
+                "text": span.get("text", ""),
+                "start": span.get("start", 0),
+                "end": span.get("end", 0),
+            }
+        )
+
+    return normalized
+
+
+@hydra.main(
+    config_path="../../config", config_name="hallucination_detection", version_base=None
+)
+def main(config: DictConfig) -> None:
+    """Run hallucination annotation over the configured QA dataset."""
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    target_dataset_name = (
+        f"{config.base_dataset.id}-{config.language}-"
+        f"{config.models.eval_model.split('/')[1]}"
+    )
+
+    logger.info(
+        "Loading dataset %s for hallucination annotation...",
+        f"{config.base_dataset.organisation}/{config.base_dataset.id}:{config.language}",
+    )
+
+    contexts, questions, answers = load_qa_data(
+        base_dataset_id=f"{config.base_dataset.organisation}/{config.base_dataset.id}:{config.language}",
+        split="test",
+        context_key=config.base_dataset.context_key,
+        question_key=config.base_dataset.question_key,
+        answer_key=config.base_dataset.answer_key,
+        squad_format=config.base_dataset.squad_format,
+        testing=config.testing,
+        max_examples=config.generation.max_examples,
+    )
+
+    generated_answers = generate_answers_from_qa_data(
+        eval_model=config.models.eval_model,
+        contexts=contexts,
+        questions=questions,
+        answers=answers,
+        lang=config.language,
+        max_new_tokens=config.generation.max_new_tokens,
+        output_jsonl_path=Path("data", "final", f"{target_dataset_name}.jsonl"),
+    )
+
+    detector_model_path = _build_detector_model_path(config)
+    logger.info("Loading hallucination detector: %s", detector_model_path)
+
+    if len(generated_answers) == 0:
+        logger.warning("No generated answers to annotate. Skipping.")
+        return
+
+    detector = HallucinationDetector(
+        method="transformer",
+        model_path=detector_model_path,
+        device_map="auto",
+        torch_dtype="auto",
+    )
+
+    # Build a lookup from question text to ground-truth answer so that
+    # the ground truth stays aligned even when generate_answers_from_qa_data
+    # reorders or skips entries (e.g. from caching or errors).
+    gt_lookup: dict[str, str] = {q: a for q, a in zip(questions, answers)}
+
+    records: list[dict[str, Any]] = []
+    logger.info("Annotating %d generated answers...", len(generated_answers))
+
+    for context, question, answer in zip(
+        generated_answers["context"],
+        generated_answers["question"],
+        generated_answers["answer"],
+    ):
+        ground_truth_answer = gt_lookup.get(question, "")
+        formatted_context = _format_context(context)
+        hallucinated_tokens = _extract_hallucinated_tokens(
+            detector=detector,
+            context=formatted_context,
+            question=question,
+            answer=answer,
+            lang=config.language,
+        )
+
+        records.append(
+            {
+                "context": formatted_context,
+                "question": question,
+                "ground_truth_answer": ground_truth_answer,
+                "answer": answer,
+                "hallucinated_tokens": hallucinated_tokens,
+            }
+        )
+
+    output_path = Path("data", "final", f"{target_dataset_name}-hallucinations.jsonl")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Writing hallucination-annotated dataset to %s", output_path)
+    with output_path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    dataset = Dataset.from_list(records)
+    dataset.save_to_disk(str(output_path) + "_hf")
+
+    logger.info("Done. Wrote %d records.", len(records))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/preprocess_ragtruth.py
+++ b/src/scripts/preprocess_ragtruth.py
@@ -1,0 +1,85 @@
+"""Preprocess the RAGTruth dataset into the project's hallucination data format."""
+
+import argparse
+import json
+from pathlib import Path
+
+from lettucedetect.datasets.hallucination_dataset import (
+    HallucinationData,
+    HallucinationSample,
+)
+
+
+def load_data(input_dir: Path) -> tuple[list[dict], list[dict]]:
+    """Load the RAG truth data.
+
+    :param input_dir: Path to the input directory.
+    """
+    responses = [
+        json.loads(line)
+        for line in (input_dir / "response.jsonl").read_text().splitlines()
+    ]
+    sources = [
+        json.loads(line)
+        for line in (input_dir / "source_info.jsonl").read_text().splitlines()
+    ]
+
+    return responses, sources
+
+
+def create_sample(response: dict, source: dict) -> HallucinationSample:
+    """Create a sample from the RAG truth data.
+
+    :param response: The response from the RAG truth data.
+    :param source: The source from the RAG truth data.
+    """
+    prompt = source["prompt"]
+
+    answer = response["response"]
+    split = response["split"]
+    task_type = source["task_type"]
+    labels = []
+
+    for label in response["labels"]:
+        start_char = label["start"]
+        end_char = label["end"]
+        labels.append(
+            {"start": start_char, "end": end_char, "label": label["label_type"]}
+        )
+
+    return HallucinationSample(
+        prompt, answer, labels, split, task_type, "ragtruth", "en"
+    )
+
+
+def main(input_dir: Path, output_dir: Path) -> None:
+    """Preprocess the RAG truth data.
+
+    :param input_dir: Path to the input directory.
+    :param output_dir: Path to the output directory.
+    """
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    responses, sources = load_data(input_dir)
+    sources_by_id = {source["source_id"]: source for source in sources}
+
+    hallucination_data = HallucinationData(samples=[])
+
+    for response in responses:
+        sample = create_sample(response, sources_by_id[response["source_id"]])
+        hallucination_data.samples.append(sample)
+
+    (output_dir / "ragtruth_data.json").write_text(
+        json.dumps(hallucination_data.to_json(), indent=4)
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_dir", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    args = parser.parse_args()
+
+    main(args.input_dir, args.output_dir)

--- a/src/scripts/translate.py
+++ b/src/scripts/translate.py
@@ -1,0 +1,702 @@
+"""Translate hallucination datasets between languages while preserving span labels."""
+
+import argparse
+import json
+import logging
+import os
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import requests
+import tqdm
+from lettucedetect.datasets.hallucination_dataset import (
+    HallucinationData,
+    HallucinationSample,
+)
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+TRANSLATION_ANSWER = """
+Translate the following text from {source_lang} to {target_lang}.
+- If the original text contains <HAL> tags, translate the content inside <HAL> tags and ensure the number of the <HAL> tags remain exactly the same in the output.
+- If the original text do not contain <HAL> tags, just translate the text.
+- Do NOT add any <HAL> tags if they were not in the original text.
+- Do NOT remove any <HAL> tags that were in the original text.
+- Do not include any additional sentences summarizing or explaining the translation.
+- Your output should be just the translated text, nothing else.
+
+{source_lang}:
+======START======
+{text}
+======END======
+
+Output in {target_lang}:
+"""
+
+TRANSLATION_PROMPT = """
+Translate the following prompt from {source_lang} to {target_lang}.
+- Translate only the given prompt.
+- Do not include any additional sentences summarizing or explaining the translation.
+- Your output should be just the translated prompt, nothing else.
+- Structured JSON objects should be translated as well by translating both the keys and values.
+
+{source_lang}:
+======START-PROMPT======
+{text}
+======END-PROMPT======
+
+Output in {target_lang}:
+"""
+
+
+TRANSLATION_PROMPT_DATA2TXT = """
+Translate the following prompt from {source_lang} to {target_lang}.
+- Translate only the given prompt.
+- Do not include any additional sentences summarizing or explaining the translation.
+- Your output should be just the translated prompt, nothing else.
+- Always translate JSON object as well by translating both the keys and values, e.g. "review_text": "..." -> should be translated to the language of the target language (e.g. "Bewertungstext": "...")
+
+{source_lang}:
+======START-PROMPT======
+{text}
+======END-PROMPT======
+
+Output in {target_lang}:
+"""
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("translator")
+
+
+class TranslationError(Exception):
+    """Exception raised for errors during translation."""
+
+    pass
+
+
+def setup_logging(output_dir: Path) -> None:
+    """Set up logging to file in the output directory.
+
+    :param output_dir: Directory to save log file
+    """
+    log_file = output_dir / "translation.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+
+def get_openai_client() -> dict[str, Any]:
+    """Get HTTP client configuration from environment variables.
+
+    :return: Dict with `url` and `headers` for chat completion requests
+    :raises ValueError: If API key is not set
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+    print(api_key)
+    print(base_url)
+    return {
+        "url": f"{base_url.rstrip('/')}/chat/completions",
+        "headers": {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    }
+
+
+@retry(
+    retry=retry_if_exception_type((Exception)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=2, max=60),
+    reraise=True,
+    before_sleep=lambda retry_state: logger.warning(
+        f"API call failed. Retrying in {retry_state.next_action.sleep if retry_state.next_action else 0} seconds... "
+        f"(Attempt {retry_state.attempt_number}/5)"
+    ),
+)
+def translate_text(
+    text: str,
+    client: dict[str, Any],
+    model: str,
+    task_type: str,
+    source_lang: str = "EN",
+    target_lang: str = "DE",
+    prompt: bool = False,
+) -> str:
+    """Translate text using OpenAI-compatible HTTP API with automatic retries.
+
+    :param text: Text to translate
+    :param client: HTTP client config (url + headers)
+    :param model: Model to use for translation
+    :param source_lang: Source language code
+    :param target_lang: Target language code
+    :param prompt: Whether the text is a prompt
+    :return: Translated text
+    :raises TranslationError: If translation fails after retries
+    """
+    if not text.strip():
+        return ""
+
+    try:
+        translation_prompt = (
+            TRANSLATION_ANSWER
+            if prompt
+            else TRANSLATION_PROMPT_DATA2TXT
+            if task_type == "Data2txt"
+            else TRANSLATION_PROMPT
+        )
+        translation_prompt = translation_prompt.format(
+            source_lang=source_lang, target_lang=target_lang, text=text
+        )
+
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": translation_prompt}],
+            "temperature": 0.4,
+        }
+        response = requests.post(
+            client["url"], headers=client["headers"], json=payload, timeout=60
+        )
+        response.raise_for_status()
+        response_json = response.json()
+
+        # Strip lines starting with the character '='
+        content = "\n".join(
+            [
+                line
+                for line in response_json["choices"][0]["message"]["content"].split(
+                    "\n"
+                )
+                if not line.strip().startswith("=")
+            ]
+        )
+
+        return content.strip()
+    except Exception as e:
+        logger.error(f"Translation error: {e!s}")
+        raise TranslationError(f"Failed to translate text: {e!s}") from e
+
+
+def merge_overlapping_spans(labels: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge overlapping hallucination spans into a single span.
+
+    :param labels: List of label spans to merge
+    :return: List of merged spans
+    """
+    if not labels:
+        return []
+
+    labels_copy = sorted(labels, key=lambda x: x["start"])
+    new_labels = []
+    current_span = labels_copy[0].copy()
+
+    for span in labels_copy[1:]:
+        if span["start"] <= current_span["end"]:
+            current_span["end"] = max(current_span["end"], span["end"])
+        else:
+            new_labels.append(current_span)
+            current_span = span.copy()
+
+    new_labels.append(current_span)
+    return new_labels
+
+
+def put_hallucination_tags(
+    sample: HallucinationSample, answer: str
+) -> tuple[str, list[dict[str, Any]]]:
+    """Add hallucination tags to the text.
+
+    :param sample: Sample containing labels
+    :param answer: Text to add tags to
+    :return: Tuple of (tagged text, merged labels)
+    """
+    # Skip the process if there are no labels
+    if not sample.labels:
+        return answer, []
+
+    labels = merge_overlapping_spans(sample.labels)
+    labels = sorted(labels, key=lambda x: (x["end"], x["start"]), reverse=True)
+    tagged_answer = answer
+
+    for label in labels:
+        start, end = label["start"], label["end"]
+        if start < 0 or end > len(tagged_answer) or start >= end:
+            logger.warning(
+                f"Invalid span: {start}-{end} for text of length {len(tagged_answer)}. Skipping."
+            )
+            continue
+
+        tagged_answer = tagged_answer[:end] + "</HAL>" + tagged_answer[end:]
+        tagged_answer = tagged_answer[:start] + "<HAL>" + tagged_answer[start:]
+
+    return tagged_answer, labels
+
+
+def find_hallucination_tags(
+    text: str, labels: list[dict[str, Any]], sample_index: int
+) -> tuple[list[tuple[int, int, str]], str]:
+    """Find hallucination tags in the translated text and remove them.
+
+    :param text: Text to search for tags
+    :param labels: Original labels
+    :param sample_index: Index of the sample
+    :return: Tuple of (list of (start, end, label) tuples, cleaned text without HAL tags)
+    """
+    if not labels:
+        return [], text
+
+    # Find all <HAL> and </HAL> tags
+    pattern = r"<(/?HAL)>"
+
+    cleaned_text = ""
+    open_tags = {}  # Maps an index to the starting position in cleaned text
+    hal_spans = []  # List to store (start, end, label) tuples
+
+    last_index = 0
+    tag_count = 0
+
+    for match in re.finditer(pattern, text):
+        start, end = match.span()
+        tag_type = match.group(1)
+
+        cleaned_text += text[last_index:start]
+
+        if tag_type == "HAL":  # Opening tag
+            open_tags[tag_count] = len(cleaned_text)
+        elif tag_type == "/HAL":  # Closing tag
+            if tag_count in open_tags:
+                label_text = "Unknown"
+                if tag_count < len(labels):
+                    label_text = labels[tag_count].get("label", "Unknown")
+                else:
+                    message = f"IndexError: No label for hallucinated text at sample ({sample_index}), span {tag_count}"
+                    logger.warning(message)
+
+                hal_spans.append((open_tags[tag_count], len(cleaned_text), label_text))
+                tag_count += 1
+            else:
+                message = f"Warning: Found closing HAL tag without matching opening tag in sample {sample_index}"
+                logger.warning(message)
+
+        last_index = end
+
+    # Add remaining text
+    cleaned_text += text[last_index:]
+
+    if tag_count < len(labels):
+        message = f"Warning: Not all hallucination spans were found in sample {sample_index}. Found {tag_count}, expected {len(labels)}"
+        logger.warning(message)
+
+    return hal_spans, cleaned_text
+
+
+def translate_sample(
+    sample: HallucinationSample,
+    client: dict[str, Any],
+    model: str,
+    sample_index: int,
+    log_file: Path,
+    source_lang: str,
+    target_lang: str,
+    dataset: str,
+) -> HallucinationSample | None:
+    """Translate a single sample.
+
+    :param sample: Sample to translate
+    :param client: HTTP client config (url + headers)
+    :param model: Model to use
+    :param sample_index: Sample index
+    :param log_file: Path to log file
+    :param source_lang: Source language code
+    :param target_lang: Target language code
+    :param dataset: Dataset name
+    :return: Translated sample or None if translation failed
+    """
+    try:
+        # Skip processing if we have an empty sample
+        if not sample.prompt.strip() or not sample.answer.strip():
+            logger.warning(
+                f"Sample {sample_index} has empty prompt or answer. Skipping."
+            )
+            return None
+
+        translated_prompt = translate_text(
+            sample.prompt, client, model, sample.task_type, source_lang, target_lang
+        )
+
+        tagged_answer, labels = put_hallucination_tags(sample, sample.answer)
+
+        translated_answer = translate_text(
+            tagged_answer,
+            client,
+            model,
+            sample.task_type,
+            source_lang,
+            target_lang,
+            prompt=True,
+        )
+
+        # Default to the translated answer (will be replaced if there are hallucination spans)
+        cleaned_answer = translated_answer
+
+        labels = []
+        if sample.labels:
+            # Get hallucination spans and cleaned text (without HAL tags)
+            hal_spans, cleaned_answer = find_hallucination_tags(
+                translated_answer, sample.labels, sample_index
+            )
+
+            for span in hal_spans:
+                start, end, label = span
+                labels.append({"start": start, "end": end, "label": label})
+
+        return HallucinationSample(
+            prompt=translated_prompt,
+            answer=cleaned_answer,
+            labels=labels,
+            split=sample.split,
+            task_type=sample.task_type,
+            dataset=dataset,
+            language=target_lang.lower(),
+        )
+    except Exception as e:
+        logger.error(f"Error translating sample {sample_index}: {e!s}")
+        with open(log_file, "a") as log:
+            log.write(f"Error translating sample {sample_index}: {e!s}\n")
+        return None
+
+
+def load_check_existing_data(output_file: Path) -> HallucinationData:
+    """Load existing data or create new data.
+
+    :param output_file: Path to the output file
+    :return: Existing HallucinationData or new empty HallucinationData
+    """
+    if output_file.exists():
+        try:
+            return HallucinationData.from_json(json.loads(output_file.read_text()))
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(
+                f"Error loading existing data: {e!s}. Starting with empty dataset."
+            )
+            return HallucinationData(samples=[])
+    else:
+        return HallucinationData(samples=[])
+
+
+def translate_sample_wrapper(args: tuple) -> HallucinationSample | None:
+    """Wrapper function for translate_sample to use with concurrent.futures.
+
+    :param args: Tuple of arguments for translate_sample
+    :return: Result of translate_sample
+    """
+    return translate_sample(*args)
+
+
+def process_batch(
+    samples: list[HallucinationSample],
+    client: dict[str, Any],
+    model: str,
+    start_idx: int,
+    log_file: Path,
+    source_lang: str,
+    target_lang: str,
+    dataset: str,
+    executor: ThreadPoolExecutor,
+) -> list[HallucinationSample]:
+    """Process a batch of samples in parallel using an existing executor.
+
+    :param samples: List of samples to process
+    :param client: HTTP client config (url + headers)
+    :param model: Model to use
+    :param start_idx: Starting index for the batch
+    :param log_file: Path to log file
+    :param source_lang: Source language code
+    :param target_lang: Target language code
+    :param dataset: Dataset name
+    :param executor: ThreadPoolExecutor to use
+    :return: List of translated samples (excluding failed translations)
+    """
+    futures = []
+    for i, sample in enumerate(samples, start=start_idx):
+        args = (sample, client, model, i, log_file, source_lang, target_lang, dataset)
+        future = executor.submit(translate_sample_wrapper, args)
+        futures.append(future)
+
+    results = []
+    for future in futures:
+        try:
+            result = future.result()
+            if result:
+                results.append(result)
+        except Exception as e:
+            logger.error(f"Error in sample processing: {e!s}")
+
+    return results
+
+
+def save_progress(
+    translated_data: HallucinationData,
+    output_file: Path,
+    dataset: str,
+    target_lang: str,
+    output_dir: Path,
+) -> None:
+    """Save progress to file with backup handling.
+
+    :param translated_data: Data to save
+    :param output_file: Primary output file
+    :param dataset: Dataset name for backup file
+    :param target_lang: Target language for backup file
+    :param output_dir: Output directory for backup file
+    """
+    try:
+        output_file.write_text(json.dumps(translated_data.to_json(), indent=2))
+    except Exception as e:
+        logger.error(f"Error saving progress: {e!s}")
+        # Try to save to a backup file
+        backup_file = (
+            output_dir
+            / f"{dataset}_data_{target_lang.lower()}_backup_{int(time.time())}.json"
+        )
+        try:
+            backup_file.write_text(json.dumps(translated_data.to_json(), indent=2))
+            logger.info(f"Saved backup to {backup_file}")
+        except Exception as e2:
+            logger.error(f"Error saving backup: {e2!s}")
+
+
+def main(
+    input_dir: Path,
+    output_dir: Path,
+    model: str,
+    source_lang: str,
+    target_lang: str,
+    dataset: str = "ragtruth",
+    batch_size: int = 5,
+    max_workers: int = 5,
+    resume: bool = True,
+    test: bool = False,
+) -> None:
+    """Translates the preprocessed data using parallel processing.
+
+    :param input_dir: Path to the input directory
+    :param output_dir: Path to the output directory
+    :param model: OpenAI model to use
+    :param source_lang: Source language code
+    :param target_lang: Target language code
+    :param dataset: Dataset name (ragtruth, ragbench, etc.)
+    :param batch_size: Number of samples to process in each batch
+    :param max_workers: Maximum number of worker threads
+    :param resume: Whether to resume from previous run
+    :param test: Test mode, only translate 1 sample
+    """
+    # Set up directories
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set up logging
+    setup_logging(output_dir)
+
+    # Set up files
+    input_file = input_dir / f"{dataset}_data.json"
+    output_file = output_dir / f"{dataset}_data_{target_lang.lower()}.json"
+    log_file = output_dir / "error_log.txt"
+
+    # Check input file
+    if not input_file.exists():
+        logger.error(f"Input file not found: {input_file}")
+        raise FileNotFoundError(f"Input file not found: {input_file}")
+
+    # Load data
+    try:
+        data = HallucinationData.from_json(json.loads(input_file.read_text()))
+    except Exception as e:
+        logger.error(f"Error loading input data: {e!s}")
+        raise
+
+    # Load existing translated data if resume is enabled
+    if resume and output_file.exists():
+        translated_data = load_check_existing_data(output_file=output_file)
+        num_processed = len(translated_data.samples)
+        logger.info(f"Resuming from {num_processed} previously translated samples")
+    else:
+        translated_data = HallucinationData(samples=[])
+        num_processed = 0
+
+    # Get samples to translate
+    remaining_samples = data.samples[num_processed:]
+    total_samples = len(remaining_samples)
+
+    if total_samples == 0:
+        logger.info("No samples to translate. Exiting.")
+        return
+
+    # Get OpenAI client
+    client = get_openai_client()
+
+    logger.info(f"Translating {dataset} from {source_lang} to {target_lang}")
+    logger.info(f"Using model: {model}")
+    logger.info(f"Total samples to process: {total_samples}")
+    logger.info(f"Batch size: {batch_size}, Max workers: {max_workers}")
+
+    # Create progress bar
+    progress_bar = tqdm.tqdm(total=total_samples, desc="Translating")
+
+    # Start time
+    start_time = time.time()
+    save_interval = 60  # Save at least every minute
+    last_save_time = start_time
+
+    try:
+        # Process samples in batches
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            for i in range(0, total_samples, batch_size):
+                if test and i > 0:
+                    break
+
+                batch = remaining_samples[i : i + batch_size]
+
+                # Process the whole batch using the existing executor
+                batch_results = process_batch(
+                    batch,
+                    client,
+                    model,
+                    num_processed + i,
+                    log_file,
+                    source_lang,
+                    target_lang,
+                    dataset,
+                    executor,
+                )
+
+                # Add results to translated data
+                translated_data.samples.extend(batch_results)
+                progress_bar.update(len(batch_results))
+
+                # Save progress periodically or at end of batch
+                current_time = time.time()
+                if (
+                    current_time - last_save_time > save_interval
+                    or i + batch_size >= total_samples
+                ):
+                    save_progress(
+                        translated_data, output_file, dataset, target_lang, output_dir
+                    )
+                    last_save_time = current_time
+
+                # Calculate and log progress
+                current_count = len(translated_data.samples)
+                elapsed_time = current_time - start_time
+                samples_per_sec = (
+                    current_count / elapsed_time if elapsed_time > 0 else 0
+                )
+
+                logger.info(
+                    f"Processed {current_count}/{num_processed + total_samples} samples "
+                    f"({samples_per_sec:.2f} samples/sec)"
+                )
+
+    except KeyboardInterrupt:
+        logger.info("Translation interrupted by user. Saving progress...")
+        save_progress(translated_data, output_file, dataset, target_lang, output_dir)
+        logger.info(
+            f"Saved {len(translated_data.samples)} translated samples to {output_file}"
+        )
+        return
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e!s}")
+        save_progress(translated_data, output_file, dataset, target_lang, output_dir)
+        raise
+
+    finally:
+        progress_bar.close()
+
+    logger.info(
+        f"Translation complete. Translated {len(translated_data.samples)} samples."
+    )
+    logger.info(f"Output saved to {output_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Translate hallucination dataset to another language"
+    )
+    parser.add_argument(
+        "--input_dir",
+        type=str,
+        required=True,
+        help="Directory containing input data files",
+    )
+    parser.add_argument(
+        "--output_dir", type=str, required=True, help="Directory to save output files"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-4o-mini",
+        help="OpenAI model to use for translation",
+    )
+    parser.add_argument(
+        "--source-lang",
+        type=str,
+        default="EN",
+        help="Source language code (e.g., EN, DE, FR, etc.)",
+    )
+    parser.add_argument(
+        "--target-lang",
+        type=str,
+        default="DE",
+        help="Target language code (e.g., EN, DE, FR, etc.)",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="ragtruth",
+        help="Dataset name (ragtruth, ragbench, etc.)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=30,
+        help="Number of samples to process in each batch",
+    )
+    parser.add_argument(
+        "--max-workers", type=int, default=30, help="Maximum number of worker threads"
+    )
+    parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Don't resume from previous run, start fresh",
+    )
+    parser.add_argument(
+        "--test", action="store_true", help="Test mode, only translate 1 sample"
+    )
+    args = parser.parse_args()
+    main(
+        Path(args.input_dir),
+        Path(args.output_dir),
+        args.model,
+        args.source_lang,
+        args.target_lang,
+        args.dataset,
+        args.batch_size,
+        args.max_workers,
+        not args.no_resume,
+        args.test,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "lettucedetect", specifier = ">=0.1.8" },
-    { name = "nltk", specifier = ">=3.9.1" },
+    { name = "nltk", specifier = ">=3.9.4" },
     { name = "openai", specifier = ">=1.4.0" },
     { name = "protobuf", specifier = ">=6.32.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -1381,7 +1381,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.1"
+version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1389,9 +1389,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Bump nltk from 3.9.1 to 3.9.4 (#17)

Bumps [nltk](https://github.com/nltk/nltk) from 3.9.1 to 3.9.4.
- [Changelog](https://github.com/nltk/nltk/blob/develop/ChangeLog)
- [Commits](https://github.com/nltk/nltk/compare/3.9.1...3.9.4)

---
updated-dependencies:
- dependency-name: nltk dependency-version: 3.9.4 dependency-type: direct:production ...




* Feat/ragtruth (#20)

* Update docker file

* Scripts from KLabs for ragtruth processing

* Ground truth eval without ragtruth

* merge

* Files from ucloud

* Import fix

* Bugfix in prompt util

* Don't shuffle

* Shuffle after split

* Add switch for ragtruth

* Linting

* Linting

* Update readme

* Add summary of ground truth analysis

* Clean up ground truth scripts

* Potential fix for pull request finding



---------



---------